### PR TITLE
feat: 适配升级后的宿舍区网络登录

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
 	},
 	"permissions": [
 		"https://drcom.szu.edu.cn/a70.htm",
-		"http://172.30.255.2/0.htm"
+		"http://172.30.255.2/0.htm",
+		"http://172.30.255.42:801/"
 	]
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,4 +1,4 @@
-import { login } from './login-post.js';
+import { login, newLogin } from './login-post.js';
 import { show, hide, warn } from './animation.js';
 
 const securityText = '*账号信息仅保存于本地，以保证隐私安全';
@@ -133,6 +133,7 @@ const showResult = (isSuccess, msg) => {
     Promise.race([
       login('nth'),
       login('wifi'),
+      newLogin(),
       timeoutTimer,
     ])
       .then((res) => {

--- a/src/js/login-post.js
+++ b/src/js/login-post.js
@@ -90,7 +90,6 @@ export function login(type) {
       }
     };
   });
-
   // 发送请求
   request.send(postBody);
 
@@ -106,8 +105,24 @@ export function newLogin() {
   const cid = localStorage.getItem('cid');
   const password = localStorage.getItem('password');
 
-  // url
-  const url = `http://172.30.255.42:801/eportal/portal/login?callback=dr1003&login_method=1&user_account=%2C0%2C${cid}&user_password=${password}&wlan_user_ip=&wlan_user_ipv6=&wlan_user_mac=000000000000&wlan_ac_ip=&wlan_ac_name=&jsVersion=4.1.3&terminal_type=1&lang=zh-cn&v=10353&lang=zh`;
+  // 构造url
+  const query = serialize({
+    callback: 'dr1003',
+    login_method: 1,
+    user_account: `%2C0%2C${cid}`,
+    user_password: password,
+    wlan_user_ip: '',
+    wlan_user_ipv6: '',
+    wlan_user_mac: '000000000000',
+    wlan_ac_ip: '',
+    wlan_ac_name: '',
+    jsVersion: '4.1.3',
+    terminal_type: 1,
+    lang: 'zh-cn',
+    v: 10353,
+    lang: 'zh',
+  });
+  const url = `http://172.30.255.42:801/eportal/portal/login?${query}`;
   request.open('GET', url, true);
 
   // 根据连接情况返回结果
@@ -137,20 +152,20 @@ export function newLogin() {
         // 以及后面的");"两个字符，得到完整JSON字符串
         const responseText = request.responseText.substring(7, request.responseText.length - 2);
 
-        // 尝试解析JSON，并记录是否成功
-        let isInfoResult = false;
-        let isSucceedResult = false;
-        let responseJson = '';
+        // 尝试解析JSON
+        let responseJson = {};
         try {
           responseJson = JSON.parse(responseText);
-          isInfoResult = true;
-          isSucceedResult = (responseJson["result"] === 1);
         } catch (e) {
-          isInfoResult = false;
-          isSucceedResult = false;
           console.error(e);
+          resolve({
+            type: false,
+            msg: `😥登陆失败：${request.responseText}`
+          });
         }
 
+        // 成功
+        const isSucceedResult = (responseJson.result === 1);
         if (isSucceedResult) {
           resolve({
             type: true,
@@ -158,25 +173,27 @@ export function newLogin() {
           });
         }
 
-        if (isInfoResult) {
-          // "IP已经在线"算作登录成功
-          if (responseJson["ret_code"] === 2) {
-            resolve({
-              type: true,
-              msg: `登录成功😊：${responseJson["msg"]}` // 顺便显示一下登录的IP
-            });
-          }
-
-          // 返回失败结果
+        // "IP已经在线"算作登录成功
+        const isAlreadyOnline = (responseJson.ret_code === 2);
+        if (isAlreadyOnline) {
           resolve({
-            type: false,
-            msg: `😥登陆失败：${responseJson["msg"]}`
+            type: true,
+            msg: `登录成功😊：${responseJson.msg}` // 顺便显示一下登录的IP
           });
         }
+
+        // 失败
+        let msg = responseJson.msg;
+        // 错误情况简单翻译
+        if (msg === 'ldap auth error') msg = `账号或密码错误（${msg}）`
+        if (msg === 'error hid') msg = `登录行为异常，请过几分钟后再试（${msg}）`
+        resolve({
+          type: false,
+          msg: `😥登陆失败：${msg}`
+        });
       }
     };
   });
-
   // 发送请求
   request.send();
 

--- a/src/js/login-post.js
+++ b/src/js/login-post.js
@@ -90,9 +90,95 @@ export function login(type) {
       }
     };
   });
-  
+
   // 发送请求
   request.send(postBody);
+
+  return result;
+}
+
+// 宿舍区宽带升级后的登录
+export function newLogin() {
+  // 创建 XMLHttpRequest 对象
+  const request = new XMLHttpRequest();
+
+  // 学号、密码
+  const cid = localStorage.getItem('cid');
+  const password = localStorage.getItem('password');
+
+  // url
+  const url = `http://172.30.255.42:801/eportal/portal/login?callback=dr1003&login_method=1&user_account=%2C0%2C${cid}&user_password=${password}&wlan_user_ip=&wlan_user_ipv6=&wlan_user_mac=000000000000&wlan_ac_ip=&wlan_ac_name=&jsVersion=4.1.3&terminal_type=1&lang=zh-cn&v=10353&lang=zh`;
+  request.open('GET', url, true);
+
+  // 根据连接情况返回结果
+  const result = new Promise((resolve, reject) => {
+    request.onreadystatechange = () => {
+      if (request.status !== 200) {
+        setTimeout(() => {
+          resolve({
+            type: false,
+            msg: '连接失败，请检查网络连接情况',
+          })
+        }, 3000);
+      }
+      if (
+        request.readyState === 4 &&
+        request.status === 200
+      ) {
+        /**
+         * 新版协议的返回格式:
+         * dr1003({\"result\":1,\"msg\":\"Portal协议认证成功！\"});
+         * dr1003({\"result\":0,\"msg\":\"账号不存在\",\"ret_code\":1});
+         * dr1003({\"result\":0,\"msg\":\"IP: 172.30.237.57 已经在线！\",\"ret_code\":2});
+         * 这里dr1003来自于GET请求中的callback参数
+         */
+
+        // 切除前面的"dr1003("一共7个字符
+        // 以及后面的");"两个字符，得到完整JSON字符串
+        const responseText = request.responseText.substring(7, request.responseText.length - 2);
+
+        // 尝试解析JSON，并记录是否成功
+        let isInfoResult = false;
+        let isSucceedResult = false;
+        let responseJson = '';
+        try {
+          responseJson = JSON.parse(responseText);
+          isInfoResult = true;
+          isSucceedResult = (responseJson["result"] === 1);
+        } catch (e) {
+          isInfoResult = false;
+          isSucceedResult = false;
+          console.error(e);
+        }
+
+        if (isSucceedResult) {
+          resolve({
+            type: true,
+            msg: '登录成功😊'
+          });
+        }
+
+        if (isInfoResult) {
+          // "IP已经在线"算作登录成功
+          if (responseJson["ret_code"] === 2) {
+            resolve({
+              type: true,
+              msg: `登录成功😊：${responseJson["msg"]}` // 顺便显示一下登录的IP
+            });
+          }
+
+          // 返回失败结果
+          resolve({
+            type: false,
+            msg: `😥登陆失败：${responseJson["msg"]}`
+          });
+        }
+      }
+    };
+  });
+
+  // 发送请求
+  request.send();
 
   return result;
 }


### PR DESCRIPTION
适配器升级后的宿舍区网络登录 #8 
原来的两个login的网络请求没有进行更改，新增了一个新的login函数。

效果如下

登录失败：
![@CH~}4BU9ST~DMXGF H(Z5T](https://user-images.githubusercontent.com/56833537/147803143-cada0446-dc5c-4b4f-98d0-e9352c61fb81.png)

首次登录：
![7O1S~798AOC$H69M64NGJUK](https://user-images.githubusercontent.com/56833537/147803180-b4e0a688-5c88-4ba9-b7cd-b6163413ebf4.png)

已经登陆时重复登录：
![O61NS9O`L](https://user-images.githubusercontent.com/56833537/147803126-25f24ed7-590f-4385-b5e6-37380eb83c2c.png)

